### PR TITLE
chore(ci): build and publish wakemebot:python-mkdocs

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -143,7 +143,7 @@ jobs:
             type=semver,pattern={{major}}
             type=ref,event=branch
 
-      - name: Build Docker image
+      - name: Build Slim Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -152,8 +152,18 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Check Docker image
+      - name: Check Slim Docker image
         run: docker run --rm -i ghcr.io/${{ github.event.repository.full_name }}:latest wakemebot --help
+
+      - name: Build Python Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: python.Dockerfile
+          tags: ghcr.io/${{ github.event.repository.full_name }}:python-mkdocs
+
+      - name: Check Python Docker image
+        run: docker run --rm -i ghcr.io/${{ github.event.repository.full_name }}:python-mkdocs wakemebot --help
 
       - name: Publish Docker image
         if: startsWith(github.ref, 'refs/tags')

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,3 @@ ARG WAKEMEBOT_PATH="dist/wakemebot"
 COPY ${WAKEMEBOT_PATH} /usr/local/bin/wakemebot
 
 USER 1001
-
-

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 Bunch of tools needed in [wakemeops](https://github.com/upciti/wakemeops) CI pipelines:
 
-* `wakemebot docs`: list debian packages published at <http://deb.wakemeops.com/wakemeops> and update wakemeops documentation.
-* `wakemebot aptly push`: push new packages to aptly.
+- `wakemebot docs`: list debian packages published at <http://deb.wakemeops.com/wakemeops> and update wakemeops documentation.
+- `wakemebot aptly push`: push new packages to aptly.
 
 ## Usage examples
 

--- a/aptly/docker-compose.yml
+++ b/aptly/docker-compose.yml
@@ -1,10 +1,17 @@
-version: '3.8'
+version: "3.8"
 
 services:
   aptly:
     build:
       context: .
     restart: always
-    command: ["aptly", "api", "serve", "-listen=unix:///var/lib/aptly/aptly.sock", "-no-lock"]
+    command:
+      [
+        "aptly",
+        "api",
+        "serve",
+        "-listen=unix:///var/lib/aptly/aptly.sock",
+        "-no-lock",
+      ]
     volumes:
       - .:/var/lib/aptly

--- a/python.Dockerfile
+++ b/python.Dockerfile
@@ -1,0 +1,36 @@
+#### Builder
+FROM wakemeops/debian:bullseye-slim as builder
+
+ENV PIP_DEFAULT_TIMEOUT=100 \
+    POETRY_VIRTUALENVS_IN_PROJECT=true
+
+WORKDIR /wakemebot
+
+RUN install_packages poetry=1.*
+
+COPY poetry.lock pyproject.toml README.md ./
+RUN poetry install --no-dev --no-interaction --no-ansi --no-root
+
+COPY src src
+RUN poetry install --no-dev --no-interaction --no-ansi
+
+
+#### CI Executor
+FROM wakemeops/debian:bullseye-slim as executor
+
+RUN install_packages \
+    rsync \
+    curl \
+    ca-certificates \
+    python3 \
+    make \
+    git
+
+ENV PATH="/wakemebot/.venv/bin:$PATH"
+
+COPY --from=builder /wakemebot /wakemebot
+
+RUN groupadd --gid 1003 wakemebot && \
+    useradd --uid 1003 --gid wakemebot --create-home wakemebot
+
+USER 1001


### PR DESCRIPTION
For the update-documentation, the new image is too small.
It lacks a lot of dependencies and it would be necessary to re-build the old image to use mkdocs

Signed-off-by: Benjamin Texier <benjamin.texier@outlook.com>